### PR TITLE
Support building mTCP with dpdk included in libmoon

### DIFF
--- a/mk/rte.app.mk
+++ b/mk/rte.app.mk
@@ -201,6 +201,11 @@ O_TO_EXE = $(LD) -o $@ $(OBJS-y) \
 	$(LDLIBS) $(LDFLAGS) $(LDFLAGS_$(@)) $(EXTRA_LDFLAGS) \
 	$(MAPFLAGS)
 endif
+#dump ldflags.txt as expected by mtcp
+$(shell if [ ! -d ${RTE_SDK}/${RTE_TARGET}/lib ]; then mkdir ${RTE_SDK}/${RTE_TARGET}/lib; fi)
+LINKER_FLAGS = $(call linkerprefix,$(LDLIBS))
+$(shell echo ${LINKER_FLAGS} > ${RTE_SDK}/${RTE_TARGET}/lib/ldflags.txt)
+
 O_TO_EXE_STR = $(subst ','\'',$(O_TO_EXE)) #'# fix syntax highlight
 O_TO_EXE_DISP = $(if $(V),"$(O_TO_EXE_STR)","  LD $(@)")
 O_TO_EXE_CMD = "cmd_$@ = $(O_TO_EXE_STR)"

--- a/mk/rte.cpuflags.mk
+++ b/mk/rte.cpuflags.mk
@@ -129,3 +129,6 @@ space:= $(empty) $(empty)
 CPUFLAGSTMP1 := $(addprefix RTE_CPUFLAG_,$(CPUFLAGS))
 CPUFLAGSTMP2 := $(subst $(space),$(comma),$(CPUFLAGSTMP1))
 CPUFLAGS_LIST := -DRTE_COMPILE_TIME_CPUFLAGS=$(CPUFLAGSTMP2)
+# create cflags.txt like expected by mtcp
+MACHINE_CFLAGS += -DRTE_COMPILE_TIME_CPUFLAGS=$(CPUFLAGSTMP2)
+$(shell echo ${MACHINE_CFLAGS} > ${RTE_SDK}/${RTE_TARGET}/include/cflags.txt)


### PR DESCRIPTION
mTCP expects the compiler and linker flags to be dumped into `cflags.txt` and `ldflags.txt`

Apply against `v16.07`